### PR TITLE
[WIP] Dockerfile: upgrade base image trafex/alpine-nginx-php7 to last php7 …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /app
 RUN composer self-update 2.1.8
 RUN composer install
 
-FROM trafex/alpine-nginx-php7:ba1dd422
+FROM trafex/alpine-nginx-php7:1.10.0
+# we need to switch to root because base image downgrades to user nobody
+USER root
 RUN apk update && apk add --no-cache busybox-suid sudo php7-redis php7-pdo php7-pdo_mysql php7-fileinfo shadow gettext bash apache2-utils
 
 COPY static/nginx/nginx.conf /etc/nginx/templateNginx.conf


### PR DESCRIPTION
…commit

Currently fails with 
```
pf           | 2021-09-22T15:53:27.078576051Z NOTICE: PHP message: Redis::set(): EXPIRE can't be < 1
pf           | 2021-09-22T15:53:27.078694016Z NOTICE: PHP message: [vendor/bcosca/fatfree-core/base.php:2314] Base->error()
pf           | 2021-09-22T15:53:27.078731166Z NOTICE: PHP message: [vendor/bcosca/fatfree-core/base.php:2605] Redis->set()
pf           | 2021-09-22T15:53:27.078745696Z NOTICE: PHP message: [vendor/bcosca/fatfree-core/base.php:1731] Cache->set()
pf           | 2021-09-22T15:53:27.078752112Z NOTICE: PHP message: [index.php:27] Base->run()

```